### PR TITLE
Rename helper functions

### DIFF
--- a/index.html
+++ b/index.html
@@ -267,10 +267,10 @@
                     allFetchedNfts.push({
                         id: `${item.token.contract.address}_${item.token.tokenId}`,
                         name: metadata.name || `Token ${item.token.tokenId}`,
-                        image: मानवIpfsUrl(metadata.displayUri || metadata.thumbnailUri || metadata.artifactUri),
+                        image: normalizeIpfsUrl(metadata.displayUri || metadata.thumbnailUri || metadata.artifactUri),
                         quantity: item.balance,
                         purchasePriceXTZ: simulatedPurchasePriceXTZ,
-                        purchasePriceUSD तत्कालीन: simulatedPurchasePriceUSD,
+                        purchasePriceUSDThen: simulatedPurchasePriceUSD,
                         purchaseDate: purchaseTimestamp, // For sorting
                         salePriceXTZ: isSold ? simulatedSalePriceXTZ : null,
                         salePriceUSD: isSold ? simulatedSalePriceUSD : null,
@@ -352,7 +352,7 @@
             }
         }
 
-        function मानवIpfsUrl(uri) {
+        function normalizeIpfsUrl(uri) {
             if (!uri) return 'https://via.placeholder.com/60?text=No+Art';
             if (uri.startsWith('ipfs://')) {
                 return `https://ipfs.io/ipfs/${uri.substring(7)}`;
@@ -403,7 +403,7 @@
                     </td>
                     <td>${nft.quantity}</td>
                     <td>${nft.purchasePriceXTZ || 'N/A'} Tez</td>
-                    <td>$${nft.purchasePriceUSD तत्कालीन || 'N/A'}</td>
+                    <td>$${nft.purchasePriceUSDThen || 'N/A'}</td>
                     <td>${nft.salePriceXTZ ? `${nft.salePriceXTZ} Tez` : 'Not Sold'}</td>
                     <td class="${nft.profitLossXTZ > 0 ? 'profit' : nft.profitLossXTZ < 0 ? 'loss' : ''}">${nft.profitLossXTZ !== null ? `${nft.profitLossXTZ} Tez` : 'N/A'}</td>
                     <td class="${nft.profitLossUSD > 0 ? 'profit' : nft.profitLossUSD < 0 ? 'loss' : ''}">${nft.profitLossUSD !== null ? `$${nft.profitLossUSD}` : 'N/A'}</td>


### PR DESCRIPTION
## Summary
- update the helper for IPFS URLs to `normalizeIpfsUrl`
- rename purchase price USD field to `purchasePriceUSDThen`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683faf5768dc8321b217be3d84f95b9a